### PR TITLE
workaround rust-lang/rust#33275

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(const_err)]
 #![no_std]
 
 #![cfg_attr(all(feature = "unstable", test), feature(plugin))]


### PR DESCRIPTION
expressions like `i32::MIN as f32` are wrongly being warned as
`const_error`s. Allow these kind of warnings until the bug is fixed.
