### PR TITLE
Implement `Error` and other convenience traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ script:
   - |
       travis-cargo build &&
       travis-cargo test &&
-      travis-cargo --only stable doc
+      travis-cargo build -- --features std &&
+      travis-cargo test -- --features std &&
+      travis-cargo --only stable doc -- --features std
 
 after_success:
   - travis-cargo --only stable doc-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_script:
 
 script:
   - |
+      travis-cargo build -- --no-default-features &&
+      travis-cargo test -- --no-default-features &&
       travis-cargo build &&
       travis-cargo test &&
-      travis-cargo build -- --features std &&
-      travis-cargo test -- --features std &&
-      travis-cargo --only stable doc -- --features std
+      travis-cargo --only stable doc
 
 after_success:
   - travis-cargo --only stable doc-upload

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ version = "0.1.0"
 [features]
 # For tests only
 unstable = ["quickcheck", "quickcheck_macros"]
+# Enable this to get a std::error::Error impl for convenient use with other
+# libraries.
+std = []
 
 [dependencies]
 # TODO these should be optional dev-dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ std = []
 [dependencies]
 # TODO these should be optional dev-dependencies.
 # cf https://github.com/rust-lang/cargo/issues/1596
-quickcheck = { version = "0.2.25", optional = true }
-quickcheck_macros = { version = "0.2.25", optional = true }
+quickcheck = { version = "0.4", optional = true }
+quickcheck_macros = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ repository = "https://github.com/japaric/cast.rs"
 version = "0.1.0"
 
 [features]
+# Assume we should use `std` unless asked to do otherwise.
+default = ["std"]
 # For tests only
 unstable = ["quickcheck", "quickcheck_macros"]
 # Enable this to get a std::error::Error impl for convenient use with other

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,14 @@
 //! # }
 //! ```
 //!
+//! ## Building without `std`
+//!
+//! This crate can be used without Rust's `std` crate by declaring it as
+//! follows in your `Cargo.toml`:
+//!
+//! ```toml
+//! cast = { version = "*", default-features = false }
+//! ```
 
 #![deny(missing_docs)]
 #![deny(warnings)]


### PR DESCRIPTION
Thank you for encouraging me to work on this PR!

This PR should fix #8, making it convenient to use `cast` with popular error-management libraries like `error-chain`. This PR will be in three parts, each of which can be considered individually:

1. Implementing `Error`, etc. This adds the necessary convenience `impl`s. See the commit message for a complete list. However, one key `impl` (for `std::error::Error` itself) can only be provided if `std` is available. So we also add an optional `std` feature (off by default) and enable conditional compilation.
2. Adding Travis CI support for testing both with and without `std`. Since we can now be built two ways, we need to test both. Again, see the commit message for a detailed explanation.
3. (Optional) Make `std` support the default. **This is an API breaking change and would require bumping the version to 0.2.0.** If you feel that most users of `cast` will be using `std`, this might be a good idea, because it will set up `Error` support with no extra tweaking. But if expect `core` to be the most common case, do not merge this final patch.

Part (3) will be along shortly; I just want to verify that part (2) builds with Travis before pushing it. Thank you for considering this patch!