### PR TITLE
Fix float -> u128 conversion bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,10 +494,11 @@ mod _x128 {
 
     // Float
     from_float! {
+        f32  => i128;
         f64  => i128, u128;
     }
     from_float_dst! {
-        f32  => i128, u128;
+        f32  => u128;
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -182,3 +182,9 @@ from_float! {
     f32 => i128, u128;
     f64 => i128, u128;
 }*/
+
+#[test]
+fn test_fl_conversion() {
+    use u128;
+    assert_eq!(u128(42.0f32), Ok(42));
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -184,6 +184,7 @@ from_float! {
 }*/
 
 #[test]
+#[cfg(feature = "x128")]
 fn test_fl_conversion() {
     use u128;
     assert_eq!(u128(42.0f32), Ok(42));


### PR DESCRIPTION
Converting floats to u128 failed because in the comparison
"src > u128::MAX as f32" we invoked UB due to the
u128::MAX as f32 conversion.