### PR TITLE
WIP: Add tests for issue #23

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -219,3 +219,10 @@ fn gh15() {
     assert_eq!(super::u16(16_f32.exp2()), Err(super::Error::Overflow));
     assert_eq!(super::u16(16_f64.exp2()), Err(super::Error::Overflow));
 }
+
+#[test]
+fn gh23() {
+    assert_eq!(super::u32(u32::MAX as f64), Ok(u32::MAX));
+    assert_eq!(super::u16(u16::MAX as f64), Ok(u16::MAX));
+    assert_eq!(super::u8(u8::MAX as f64), Ok(u8::MAX));
+}


### PR DESCRIPTION
It looks like all of {u8, u16, u32}::MAX values as f64 yield Overflow
when cast back to their original types.

This is just to add tests; I haven't tried to fix the bug yet.