### PR TITLE
Update to the 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["checked", "cast", "primitive", "integer", "float"]
 license = "MIT OR Apache-2.0"
 name = "cast"
 repository = "https://github.com/japaric/cast.rs"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2018"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "cast"
 repository = "https://github.com/japaric/cast.rs"
 version = "0.2.3"
+edition = "2018"
 
 [features]
 # Assume we should use `std` unless asked to do otherwise.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(feature = "x128", not(stable_i128)), feature(i128_type, i128))]
 
-#[cfg(feature = "std")]
-extern crate core;
+
 
 #[cfg(test)]
 #[macro_use]
@@ -144,7 +143,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description_helper())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub trait From<Src> {
     type Output;
 
     /// Checked cast from `Src` to `Self`
-    fn cast(Src) -> Self::Output;
+    fn cast(_: Src) -> Self::Output;
 }
 
 macro_rules! fns {
@@ -417,7 +417,7 @@ mod _32 {
 
 #[cfg(target_pointer_width = "64")]
 mod _64 {
-    use {Error, From};
+    use crate::{Error, From};
 
     // Signed
     promotion! {

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,7 +6,7 @@ macro_rules! promote_and_back {
             $(
                 mod $src {
                     mod from {
-                        use From;
+                        use crate::From;
 
                         $(
                             quickcheck! {
@@ -78,7 +78,7 @@ macro_rules! symmetric_cast_between {
                     mod and {
                         use quickcheck::TestResult;
 
-                        use From;
+                        use crate::From;
 
                         $(
                             quickcheck! {
@@ -130,7 +130,7 @@ macro_rules! from_float {
             mod $src {
                 mod inf {
                     mod to {
-                        use {Error, From};
+                        use crate::{Error, From};
 
                         $(
                             #[test]
@@ -151,7 +151,7 @@ macro_rules! from_float {
 
                 mod nan {
                     mod to {
-                        use {Error, From};
+                        use crate::{Error, From};
 
                         $(
                             #[test]


### PR DESCRIPTION
Currently this crate cannot be parsed by syn (https://github.com/dtolnay/syn/issues/972) because it uses deprecated `fn(Src)` trait method syntax. This was updated in the edition, I decided to go ahead and do a full upgrade to the 2018 edition anyway.

Happy to pare it back to just fixing the trait method syntax instead of a full edition upgrade, but the upgrade seemed pretty minor so I hope you don't mind.

r? @japaric