### PR TITLE
Update rustc_version to 0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ std = []
 x128 = []
 
 [build-dependencies]
-rustc_version = "0.2.3"
+rustc_version = "0.3.3"
 
 [dev-dependencies]
 quickcheck = "0.9.0"


### PR DESCRIPTION
I think this is the cause of the build failures I'm seeing in https://github.com/bytecodealliance/wasmtime/pull/2888: cargo deny sees two different versions of `rustc_version`.