### PR TITLE
Bump to rustc_version 0.4.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ std = []
 x128 = []
 
 [build-dependencies]
-rustc_version = "0.3.3"
+rustc_version = "0.4.0"
 
 [dev-dependencies]
 quickcheck = "0.9.0"


### PR DESCRIPTION
This helps downstream users which depend on 0.4.0 in other ways to avoid depending on multiple versions, which can cause problems in projects that use cargo deny to prohibit having multiple versions of a crate.