### PR TITLE
Breaking change: Enable 128-bit integer support by default; increase MSRV.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,3 @@ jobs:
         with:
           command: test
           args: --target ${{ matrix.target }} --no-default-features
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target ${{ matrix.target }} --features x128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- The guaranteed MSRV is now 1.46.0.
+- The x128 feature has been removed; 128-bit integer support is now always
+  available by default.
+
 ## [v0.2.7] - 2021-07-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
-build = "build.rs"
 description = "Ergonomic, checked cast functions for primitive types"
 documentation = "https://docs.rs/cast"
 keywords = ["checked", "cast", "primitive", "integer", "float"]
 license = "MIT OR Apache-2.0"
 name = "cast"
 repository = "https://github.com/japaric/cast.rs"
-version = "0.2.7"
+version = "0.3.0"
 edition = "2018"
 
 [features]
@@ -16,11 +15,6 @@ default = ["std"]
 # Enable this to get a std::error::Error impl for convenient use with other
 # libraries.
 std = []
-# Enable this for i128/u128 support
-x128 = []
-
-[build-dependencies]
-rustc_version = "0.4.0"
 
 [dev-dependencies]
 quickcheck = "0.9.0"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-extern crate rustc_version;
-
-fn main() {
-    let vers = rustc_version::version().unwrap();
-    if vers.major == 1 && vers.minor >= 26 {
-        println!("cargo:rustc-cfg=stable_i128")
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,6 @@
 #![deny(warnings)]
 #![allow(const_err)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(feature = "x128", not(stable_i128)), feature(i128_type, i128))]
-
-
 
 #[cfg(test)]
 #[macro_use]
@@ -180,7 +177,6 @@ macro_rules! fns {
 
 fns!(f32, f64, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
 
-#[cfg(feature = "x128")]
 fns!(i128, u128);
 
 /// `$dst` can hold any value of `$src`
@@ -324,7 +320,6 @@ macro_rules! from_float {
 
 /// From a float `$src` to an integer `$dst`, where $dst is large enough to contain
 /// all values of `$src`. We can't ever overflow here
-#[cfg(feature = "x128")]
 macro_rules! from_float_dst {
     ($($src:ident => $($dst:ident),+);+;) => {
         $(
@@ -472,7 +467,6 @@ mod _64 {
     }
 }
 
-#[cfg(feature = "x128")]
 mod _x128 {
     use crate::{Error, From};
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -24,47 +24,36 @@ macro_rules! promote_and_back {
 
 #[cfg(target_pointer_width = "32")]
 promote_and_back! {
-    i8    => f32, f64,     i16, i32, isize, i64                          ;
-    i16   => f32, f64,          i32, isize, i64                          ;
-    i32   => f32, f64,                      i64                          ;
-    isize => f32, f64,                      i64                          ;
-    i64   => f32, f64                                                    ;
-    u8    => f32, f64,     i16, i32, isize, i64,     u16, u32, usize, u64;
-    u16   => f32, f64,          i32, isize, i64,          u32, usize, u64;
-    u32   => f32, f64,                      i64,                      u64;
-    usize => f32, f64,                      i64,                      u64;
-    u64   => f32, f64                                                    ;
+    i8    => f32, f64,     i16, i32, isize, i64, i128                            ;
+    i16   => f32, f64,          i32, isize, i64, i128                            ;
+    i32   => f32, f64,                      i64, i128                            ;
+    isize => f32, f64,                      i64, i128                            ;
+    i64   => f32, f64,                           i128                            ;
+    u8    => f32, f64,     i16, i32, isize, i64, i128, u16, u32, usize, u64, u128;
+    u16   => f32, f64,          i32, isize, i64, i128,      u32, usize, u64, u128;
+    u32   => f32, f64,                      i64, i128,                  u64, u128;
+    usize => f32, f64,                      i64, i128,                  u64, u128;
+    u64   => f32, f64,                           i128,                       u128;
 }
 
 #[cfg(target_pointer_width = "64")]
 promote_and_back! {
-    i8    => f32, f64,     i16, i32, i64, isize                          ;
-    i16   => f32, f64,          i32, i64, isize                          ;
-    i32   => f32, f64,               i64, isize                          ;
-    i64   => f32, f64                                                    ;
-    isize => f32, f64                                                    ;
-    u8    => f32, f64,     i16, i32, i64, isize,     u16, u32, u64, usize;
-    u16   => f32, f64,          i32, i64, isize,          u32, u64, usize;
-    u32   => f32, f64,               i64, isize,               u64, usize;
-    u64   => f32, f64                                                    ;
-    usize => f32, f64                                                    ;
+    i8    => f32, f64,     i16, i32, i64, isize, i128                            ;
+    i16   => f32, f64,          i32, i64, isize, i128                            ;
+    i32   => f32, f64,               i64, isize, i128                            ;
+    i64   => f32, f64,                           i128                            ;
+    isize => f32, f64,                           i128                            ;
+    u8    => f32, f64,     i16, i32, i64, isize, i128, u16, u32, u64, usize, u128;
+    u16   => f32, f64,          i32, i64, isize, i128,      u32, u64, usize, u128;
+    u32   => f32, f64,               i64, isize, i128,           u64, usize, u128;
+    u64   => f32, f64,                           i128,                       u128;
+    usize => f32, f64,                           i128,                       u128;
 }
 
-// TODO uncomment this once quickcheck supports Arbitrary for i128/u128
-// https://github.com/BurntSushi/quickcheck/issues/162
-/*#[cfg(feature = "x128")]
+// TODO uncomment this.
+/*
 promote_and_back! {
-    i8    =>           i128      ;
-    i16   =>           i128      ;
-    i32   =>           i128      ;
-    isize =>           i128      ;
-    i64   =>           i128      ;
     i128  => f32, f64            ;
-    u8    =>           i128, u128;
-    u16   =>           i128, u128;
-    u32   =>           i128, u128;
-    usize =>           i128, u128;
-    u64   =>           i128, u128;
     u128  => f32, f64            ;
 }*/
 
@@ -110,19 +99,13 @@ symmetric_cast_between! {
 
 #[cfg(target_pointer_width = "64")]
 symmetric_cast_between! {
-    u8    =>           i8                      ;
-    u16   =>           i8, i16                 ;
-    u32   =>           i8, i16, i32            ;
-    u64   =>           i8, i16, i32, i64, isize;
-    usize =>           i8, i16, i32, i64, isize;
+    u8    =>           i8                            ;
+    u16   =>           i8, i16                       ;
+    u32   =>           i8, i16, i32                  ;
+    u64   =>           i8, i16, i32, i64, isize      ;
+    usize =>           i8, i16, i32, i64, isize      ;
+    u128  =>           i8, i16, i32, i64, isize, i128;
 }
-
-// TODO uncomment this once quickcheck supports Arbitrary for i128/u128
-// https://github.com/BurntSushi/quickcheck/issues/162
-/*#[cfg(feature = "x128")]
-symmetric_cast_between! {
-    u128  => i8, i16, i32, isize, i64, i128;
-}*/
 
 macro_rules! from_float {
     ($($src:ident => $($dst:ident),+);+;) => {
@@ -171,20 +154,11 @@ macro_rules! from_float {
 }
 
 from_float! {
-    f32 => i8, i16, i32, i64, isize, u8, u16, u32, u64, usize;
-    f64 => i8, i16, i32, i64, isize, u8, u16, u32, u64, usize;
+    f32 => i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize;
+    f64 => i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize;
 }
 
-// TODO uncomment this once quickcheck supports Arbitrary for i128/u128
-// https://github.com/BurntSushi/quickcheck/issues/162
-/*#[cfg(feature = "x128")]
-from_float! {
-    f32 => i128, u128;
-    f64 => i128, u128;
-}*/
-
 #[test]
-#[cfg(feature = "x128")]
 fn test_fl_conversion() {
     use crate::u128;
     assert_eq!(u128(42.0f32), Ok(42));


### PR DESCRIPTION
Eliminate the need for a build script, and eliminate the rustc_version dependency,
to make cast.rs a more lightweight dependency for users. Increase the MSRV to 1.46.0
to match quickcheck 1.0.

I documented the MSRV to be 1.46.0 because I found `cargo test` fails to build the
dependencies with 1.26.0, and it looks like arbitrary 1.0 has 1.46.0 as its MSRV.

I didn't upgrade the arbitrary dependency to 1.0 because some of the tests fail when
I tried.