### PR TITLE
lower MSRV to 1.31 and test it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.26.0
+          toolchain: 1.31.0
           target: ${{ matrix.target }}
           override: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 name: Continuous integration
 
 jobs:
-   test :
+  test :
     name: Test Suite
     runs-on: ubuntu-latest
 
@@ -34,4 +34,34 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --target ${{ matrix.target }} --no-default-features
+
+  # only cargo build
+  msrv:
+    name: MSRV check
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-musl
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.26.0
+          target: ${{ matrix.target }}
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.target }}
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
           args: --target ${{ matrix.target }} --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- The guaranteed MSRV is now 1.46.0.
+- The guaranteed MSRV is now 1.31.0.
 - The x128 feature has been removed; 128-bit integer support is now always
   available by default.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! Use these functions to perform a cast from any other numeric primitive:
 //!
 //! ```
-//! extern crate cast;
-//!
 //! use cast::{u8, u16, Error};
 //!
 //! # fn main() {
@@ -28,8 +26,6 @@
 //! be in the same scope:
 //!
 //! ```
-//! extern crate cast;
-//!
 //! use std::u8;
 //! use cast::{u8, u16};
 //!
@@ -47,8 +43,6 @@
 //! `cast` static method:
 //!
 //! ```
-//! extern crate cast;
-//!
 //! use std::os::raw::c_ulonglong;
 //! // NOTE avoid shadowing `std::convert::From` - cf. rust-lang/rfcs#1311
 //! use cast::From as _0;
@@ -63,8 +57,6 @@
 //! casted to `u32`.
 //!
 //! ```
-//! extern crate cast;
-//!
 //! fn to_u32<T>(x: T) -> u32
 //!     // reads as: "where u32 can be casted from T with output u32"
 //!     where u32: cast::From<T, Output=u32>,
@@ -83,8 +75,9 @@
 //!
 //! ## Minimal Supported Rust Version
 //!
-//! This crate is guaranteed to compile on stable Rust 1.13 and up. It *might* compile on older
-//! versions but that may change in any new patch release.
+//! This crate is guaranteed to compile *as a dependency* on stable Rust 1.31 and up.
+//! It's not guaranteed that `cargo test`-ing this crate follows the MSRV.
+//! It *might* compile on older versions but that may change in any new patch release.
 //!
 //! ## Building without `std`
 //!


### PR DESCRIPTION
make it explicit that MSRV does not cover `cargo test`-ing this crate
remove unidiomatic edition 2015 syntax from API documentation

---

We can lower the MSRV if we only claim that the crate can be *built* with the specified version. When used as a dependency, the dev-dependencies (like `quickcheck`) won't be built so that ought to be fine (`cast` has no `dependencies`, only `dev-dependencies`).

Also, I'd like to *not* make the MSRV depend on third party crates because they (or their recursive dependencies) may change their *actual* (which is not the same as documented) MSRV at any time.

cc @briansmith 