### PR TITLE
remove unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,11 @@
 //! cast = { version = "*", default-features = false }
 //! ```
 
-#![deny(missing_docs)]
-#![deny(warnings)]
 #![allow(const_err)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+#![deny(warnings)]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ macro_rules! from_signed {
 
 /// From a float `$src` to an integer `$dst`
 macro_rules! from_float {
-    ($($src:ident, $usrc:ident => $($dst:ident),+);+;) => {
+    ($($src:ident => $($dst:ident),+);+;) => {
         $(
             $(
                 impl From<$src> for $dst {
@@ -283,10 +283,7 @@ macro_rules! from_float {
                             // we subtract 1 ULP (unit of least precision) here because some
                             // lossy conversions like `u64::MAX as f64` round *up* and we want
                             // to avoid this evaluating to false in that case
-                            use core::mem::transmute;
-                            let max = unsafe {
-                                transmute::<_, $src>(transmute::<_, $usrc>($dst::MAX as $src) - 1)
-                            };
+                            let max = $src::from_bits(($dst::MAX as $src).to_bits() - 1);
                             src > max
                         } {
                             Error::Overflow
@@ -397,8 +394,8 @@ mod _32 {
     }
 
     from_float! {
-        f32, u32 =>        i8, i16, i32, isize, i64, u8, u16, u32, usize, u64;
-        f64, u64 =>        i8, i16, i32, isize, i64, u8, u16, u32, usize, u64;
+        f32 =>             i8, i16, i32, isize, i64, u8, u16, u32, usize, u64;
+        f64 =>             i8, i16, i32, isize, i64, u8, u16, u32, usize, u64;
     }
 }
 
@@ -455,8 +452,8 @@ mod _64 {
     }
 
     from_float! {
-        f32, u32  =>       i8, i16, i32, i64, isize, u8, u16, u32, u64, usize;
-        f64, u64  =>       i8, i16, i32, i64, isize, u8, u16, u32, u64, usize;
+        f32 =>             i8, i16, i32, i64, isize, u8, u16, u32, u64, usize;
+        f64 =>             i8, i16, i32, i64, isize, u8, u16, u32, u64, usize;
     }
 }
 
@@ -501,13 +498,13 @@ mod _x128 {
     }
 
     // Float
-    from_float! {
-        f32, u32  => i128;
-        f64, u64  => i128, u128;
+    from_float_dst! {
+        f32 =>                                                                u128;
     }
 
-    from_float_dst! {
-        f32       =>       u128;
+    from_float! {
+        f32 =>                                i128;
+        f64 =>                                i128,                           u128;
     }
 }
 


### PR DESCRIPTION
use {f32,f64}::{from_bits,to_bits} (1.20 API)